### PR TITLE
Border Color Functions

### DIFF
--- a/10vq2t5r.uzo.txt
+++ b/10vq2t5r.uzo.txt
@@ -1,0 +1,18 @@
+﻿Border color functions.
+
+Added functions to Set, Get and Change border color.
+
+To test,:
+Open CSnap locally.
+Do a File-> Import-> (a local copy of Graffiti.xml)
+In the script, remove the "set border color to pen color" block.
+Sub in, "Set border shade to" and change the default to 0.
+Run the app to see that the border color is now black.
+
+For further testing, lower in the script, (the if-else statement) you can sub in the "change border shade by ?" or "set border shade to" blocks.
+
+Future consideration: Should we get rid of the "Set border color to" block?
+
+
+#
+

--- a/objects.js
+++ b/objects.js
@@ -622,6 +622,24 @@ SpriteMorph.prototype.initBlocks = function () {
             spec: 'set border color to %n',
             defaults: [0]
         },
+		//add Border Shade functionality - Get, Set, and Change
+		getBorderShade: {
+				"type": "reporter",
+				"category": "pen",
+				"spec": "border shade"
+		},
+		setBorderShade: {
+					"type": "command",
+					"category": "pen",
+					"spec": "set border shade to %n",
+					"defaults": [100]
+		},
+		changeBorderShade: {
+					"type": "command",
+					"category": "pen",
+					"spec": "change border shade by %n",
+					"defaults": [100]
+		},		
         penBorderColor: {
             type: 'reporter',
             category: 'pen',
@@ -1965,6 +1983,9 @@ SpriteMorph.prototype.blockTemplates = function (category) {
         blocks.push(block('penSize'))
         blocks.push('-');
         blocks.push(block('setBorderHue'));
+		blocks.push(block('getBorderShade'));
+		blocks.push(block('setBorderShade'));
+		blocks.push(block('changeBorderShade'));
         blocks.push(watcherToggle('penBorderColor'))
         blocks.push(block('penBorderColor'))
         blocks.push('-');
@@ -3007,6 +3028,47 @@ SpriteMorph.prototype.setBorderHue = function (num) {
     }
     this.gotoXY(x, y);
 };
+
+//add border shade functionality - Get, Set, and Change
+
+SpriteMorph.prototype.getBorderShade = (function () {
+	return function () {
+		return this.borderColor.hsv()[2] * 50;
+	};
+}());
+
+SpriteMorph.prototype.setBorderShade = (function () {
+	return function (num) {
+      var hsv = this.borderColor.hsv(),
+        x = this.xPosition(),
+        y = this.yPosition();
+			
+		//Num goes in 0-100 range. 0 is black, 50 is the unchanged hue, 100 is white
+		num = Math.max(Math.min(+num || 0, 100), 0) / 50;
+		hsv[1] = 1;
+		hsv[2] = 1;
+
+		if(num > 1) {
+			hsv[1] = (2 - num); //Make it more white
+		}
+		else {
+			hsv[2] = num; //Make it more black
+		}
+
+		this.borderColor.set_hsv.apply(this.borderColor, hsv);
+		if (!this.costume) {
+			this.drawNew();
+			this.changed();
+		}
+		this.gotoXY(x, y);
+	};
+}());
+
+SpriteMorph.prototype.changeBorderShade = (function () {
+	return function (delta) {
+		this.setBorderShade(this.getBorderShade() + (+delta || 0));
+	};
+}());
 
 SpriteMorph.prototype.getBrightness = function () {
     return this.color.hsv()[2] * 100;


### PR DESCRIPTION
Added functions to Set, Get and Change border color.
To test,:
Open CSnap locally.
Do a File-> Import-> (a local copy of Graffiti.xml)
In the script, remove the "set border color to pen color" block.
Sub in, "Set border shade to" and change the default to 0.
Run the app to see that the border color is now black.

For further testing, lower in the script, (the if-else statement) you
can sub in the "change border shade by ?" or "set border shade to"
blocks.

Includes correction per James, 

from:
SpriteMorph.prototype.getBorderShade = (function () {
	return function () {
		return this.borderColor.hsv()[2] * 100;

to:
SpriteMorph.prototype.getBorderShade = (function () {
+	return function () {
+		return this.borderColor.hsv()[2] * 50;