### PR TITLE
Added a check for if one of the dimensions is 0

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -1658,8 +1658,11 @@ SpriteMorph.prototype.drawNew = function () {
         }
     }
     this.version = Date.now();
-    this.originalPixels = this.image.getContext('2d').createImageData(this.width(), this.height());
-    this.originalPixels = this.image.getContext('2d').getImageData(0, 0, this.width(), this.height());
+    if(this.width() >0 && this.height() >0)
+    {
+        this.originalPixels = this.image.getContext('2d').createImageData(this.width(), this.height());
+        this.originalPixels = this.image.getContext('2d').getImageData(0, 0, this.width(), this.height());
+    }
 };
 
 SpriteMorph.prototype.endWarp = function () {


### PR DESCRIPTION
There is a bug when the height is much larger than the width, and the costume size is set to 0. This should fix that.