### PR TITLE
Fix change border shade

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -3015,7 +3015,7 @@ SpriteMorph.prototype.setBorderHue = function (num) {
 
 SpriteMorph.prototype.getBorderShade = (function () {
 	return function () {
-		return ((this.borderColor.hsv()[2] * 50) + (50 - (this.borderColor.hsv()[2] * 50)));
+		return ((this.borderColor.hsv()[2] * 50) + (50 - (this.borderColor.hsv()[1] * 50)));
 	};
 }());
 

--- a/objects.js
+++ b/objects.js
@@ -3015,7 +3015,7 @@ SpriteMorph.prototype.setBorderHue = function (num) {
 
 SpriteMorph.prototype.getBorderShade = (function () {
 	return function () {
-		return this.borderColor.hsv()[2] * 50;
+		return ((this.borderColor.hsv()[2] * 50) + (50 - (this.borderColor.hsv()[2] * 50)));
 	};
 }());
 
@@ -3052,7 +3052,7 @@ SpriteMorph.prototype.changeBorderShade = (function () {
 	};
 }());
 SpriteMorph.prototype.getBrightness = function () {
-    return this.color.hsv()[2] * 100;
+    return (this.color.hsv()[2] * 50) + (50 - (this.color.hsv()[1] * 50));
 };
 
 SpriteMorph.prototype.setBrightness = function (num) {
@@ -3080,9 +3080,12 @@ SpriteMorph.prototype.setBrightness = function (num) {
     this.gotoXY(x, y);
 };
 
-SpriteMorph.prototype.changeBrightness = function (delta) {
-    this.setBrightness(this.getBrightness() + (+delta || 0));
-};
+
+SpriteMorph.prototype.changeBrightness = (function () {
+	return function (delta) {
+		this.setBrightness(this.getBrightness() + (+delta || 0));
+	};
+}());
 
 // SpriteMorph layers
 


### PR DESCRIPTION
Fixes the get_____Shade() functions maxing out at 50 and not reaching 50->100 values because it wasn't incorporating saturation (hsv[1]) into the math, only reading in hsv[2].

First contribution to CSnap so let me know if I messed anything up. 🍔 

Given that the Meyers kids are using shade in their tutorial for geometry control, might consider this high priority.

![screen shot 2017-11-30 at 4 48 32 pm](https://user-images.githubusercontent.com/23264375/33456768-664e73fc-d5ee-11e7-991c-b9c616e22d1c.png)
![screen shot 2017-11-30 at 4 48 42 pm](https://user-images.githubusercontent.com/23264375/33456777-6e2d0b10-d5ee-11e7-822c-5d711a4f13a3.png)

